### PR TITLE
Make strings and dates displayable

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -247,13 +247,23 @@ System.register(['moment', 'lodash'], function(exports_1) {
                     if (target || target == 0) {
                         items.forEach(function (item) {
                             if (item.properties[2].value == target) {
-                                series.push([parseFloat(item.properties[0][item.valueAttribute]), moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                                if (item.properties[0].valueType == "string" || item.properties[0].valueType == "isodatetime") {
+                                    series.push([item.properties[0][item.valueAttribute], moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                                }
+                                else {
+                                    series.push([parseFloat(item.properties[0][item.valueAttribute]), moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                                }
                             }
                         });
                     }
                     else {
                         items.forEach(function (item) {
-                            series.push([parseFloat(item.properties[0][item.valueAttribute]), moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                            if (item.properties[0].valueType == "string" || item.properties[0].valueType == "isodatetime") {
+                                series.push([item.properties[0][item.valueAttribute], moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                            }
+                            else {
+                                series.push([parseFloat(item.properties[0][item.valueAttribute]), moment_1.default(item.properties[1].value + tzOffset).valueOf()]);
+                            }
                         });
                     }
                     return series;


### PR DESCRIPTION
Remove use of the parseFloat() function on strings and date metric data that was causing them to show up improperly in Grafana. 